### PR TITLE
Rewrite tests using unittest

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,21 @@
+"""Tests for the command line interface."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+
 from codeatlas import cli
 
 
-def test_cli_runs(tmp_path):
-    assert cli.main(["--root", str(tmp_path)]) == 0
+class TestCLI(unittest.TestCase):
+    """Unit tests for :mod:`codeatlas.cli`."""
+
+    def test_cli_runs(self) -> None:
+        """``main`` should return ``0`` for a minimal invocation."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self.assertEqual(cli.main(["--root", tmpdir]), 0)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    unittest.main()

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -1,22 +1,36 @@
+"""Tests for text extraction utilities."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
 from pathlib import Path
 
-from codeatlas.extractor import read_text, detect_encoding
+from codeatlas.extractor import read_text
 
 
-def test_read_text(tmp_path: Path) -> None:
-    p = tmp_path / "sample.txt"
-    p.write_text("hello")
-    assert read_text(p) == "hello"
+class TestExtractor(unittest.TestCase):
+    """Unit tests for :mod:`codeatlas.extractor`."""
+
+    def test_read_text(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            p = Path(tmpdir) / "sample.txt"
+            p.write_text("hello")
+            self.assertEqual(read_text(p), "hello")
+
+    def test_truncation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            p = Path(tmpdir) / "long.txt"
+            p.write_text("abcdef")
+            self.assertEqual(read_text(p, max_bytes=3), "abc")
+
+    def test_non_utf8(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            p = Path(tmpdir) / "latin1.txt"
+            data = "café".encode("latin-1")
+            p.write_bytes(data)
+            self.assertEqual(read_text(p), "café")
 
 
-def test_truncation(tmp_path: Path) -> None:
-    p = tmp_path / "long.txt"
-    p.write_text("abcdef")
-    assert read_text(p, max_bytes=3) == "abc"
-
-
-def test_non_utf8(tmp_path: Path) -> None:
-    p = tmp_path / "latin1.txt"
-    data = "café".encode("latin-1")
-    p.write_bytes(data)
-    assert read_text(p) == "café"
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    unittest.main()

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -1,29 +1,39 @@
+"""Tests for directory scanning utilities."""
+
+from __future__ import annotations
+
+import unittest
 from pathlib import Path
 
-from codeatlas.scanner import FileEntry, scan
+from codeatlas.scanner import scan
+
 
 FIXTURE = Path(__file__).parent / "fixtures" / "simple_tree"
 
 
-def test_scan_returns_all_files():
-    entries = scan(FIXTURE)
-    names = {entry.path.as_posix() for entry in entries}
-    assert names == {"foo.txt", "sub/bar.txt", "sub/skip.log"}
+class TestScanner(unittest.TestCase):
+    """Unit tests for :mod:`codeatlas.scanner`."""
+
+    def test_scan_returns_all_files(self) -> None:
+        entries = scan(FIXTURE)
+        names = {entry.path.as_posix() for entry in entries}
+        self.assertEqual(names, {"foo.txt", "sub/bar.txt", "sub/skip.log"})
+
+    def test_scan_respects_exclude(self) -> None:
+        entries = scan(FIXTURE, exclude=["*.log"])
+        names = {entry.path.as_posix() for entry in entries}
+        self.assertEqual(names, {"foo.txt", "sub/bar.txt"})
+
+    def test_scan_include_patterns(self) -> None:
+        entries = scan(FIXTURE, include=["*.txt"])
+        names = {entry.path.as_posix() for entry in entries}
+        self.assertEqual(names, {"foo.txt", "sub/bar.txt"})
+
+    def test_scan_with_contents(self) -> None:
+        entries = scan(FIXTURE, include_contents=True)
+        foo = next(e for e in entries if e.path.name == "foo.txt")
+        self.assertEqual(foo.content, "foo\n")
 
 
-def test_scan_respects_exclude():
-    entries = scan(FIXTURE, exclude=["*.log"])
-    names = {entry.path.as_posix() for entry in entries}
-    assert names == {"foo.txt", "sub/bar.txt"}
-
-
-def test_scan_include_patterns():
-    entries = scan(FIXTURE, include=["*.txt"])
-    names = {entry.path.as_posix() for entry in entries}
-    assert names == {"foo.txt", "sub/bar.txt"}
-
-
-def test_scan_with_contents():
-    entries = scan(FIXTURE, include_contents=True)
-    foo = next(e for e in entries if e.path.name == "foo.txt")
-    assert foo.content == "foo\n"
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    unittest.main()


### PR DESCRIPTION
## Summary
- migrate pytest-style tests to `unittest`
- add explicit TestCase classes for CLI, extractor and scanner utilities

## Testing
- `python -m unittest -v`
