### PR TITLE
Add basic output formatters

### DIFF
--- a/src/codeatlas/formatter/__init__.py
+++ b/src/codeatlas/formatter/__init__.py
@@ -1,1 +1,13 @@
-"""Output formatters."""
+"""Output formatters.
+
+This module exposes simple helpers for turning :class:`~codeatlas.scanner.FileEntry`
+objects into different textual representations.  The individual formatters live in
+``text.py``, ``markdown.py`` and ``json_.py``.
+"""
+
+from .text import to_text
+from .markdown import to_markdown
+from .json_ import to_json
+
+__all__ = ["to_text", "to_markdown", "to_json"]
+

--- a/src/codeatlas/formatter/json_.py
+++ b/src/codeatlas/formatter/json_.py
@@ -1,1 +1,24 @@
 """JSON formatter."""
+
+from __future__ import annotations
+
+import json
+from typing import Iterable
+
+from ..scanner import FileEntry
+
+
+def to_json(entries: Iterable[FileEntry]) -> str:
+    """Return ``entries`` serialized as a JSON string."""
+
+    data = [
+        {
+            "path": e.path.as_posix(),
+            "size": e.size,
+            "mtime": e.mtime,
+            "content": e.content,
+        }
+        for e in entries
+    ]
+    return json.dumps(data, ensure_ascii=False, indent=2)
+

--- a/src/codeatlas/formatter/markdown.py
+++ b/src/codeatlas/formatter/markdown.py
@@ -1,1 +1,25 @@
 """Markdown formatter."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from ..scanner import FileEntry
+
+
+def _format_entry(entry: FileEntry) -> str:
+    """Return a string representation of ``entry`` as a Markdown section."""
+
+    lines = [f"### {entry.path.as_posix()}", f"- size: {entry.size}"]
+    if entry.content is not None:
+        lines.append("```")
+        lines.append(entry.content)
+        lines.append("```")
+    return "\n".join(lines)
+
+
+def to_markdown(entries: Iterable[FileEntry]) -> str:
+    """Return ``entries`` serialized as a Markdown document."""
+
+    return "\n\n".join(_format_entry(e) for e in entries)
+

--- a/src/codeatlas/formatter/text.py
+++ b/src/codeatlas/formatter/text.py
@@ -1,1 +1,23 @@
-"""Text formatter."""
+"""Plain text formatter."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from ..scanner import FileEntry
+
+
+def _format_entry(entry: FileEntry) -> str:
+    """Return a string representation of ``entry`` in plain text."""
+
+    line = f"{entry.path.as_posix()} (size={entry.size})"
+    if entry.content is None:
+        return line
+    return f"{line}\n{entry.content}"
+
+
+def to_text(entries: Iterable[FileEntry]) -> str:
+    """Return ``entries`` serialized as a plain text document."""
+
+    return "\n".join(_format_entry(e) for e in entries)
+

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -1,0 +1,29 @@
+import json
+from pathlib import Path
+
+from codeatlas.formatter import to_text, to_markdown, to_json
+from codeatlas.scanner import FileEntry
+
+
+def sample_entries():
+    return [FileEntry(Path('foo.txt'), size=3, mtime=0.0, content='foo')]
+
+
+def test_to_text():
+    out = to_text(sample_entries())
+    assert 'foo.txt' in out
+    assert 'foo' in out
+
+
+def test_to_markdown():
+    out = to_markdown(sample_entries())
+    assert '### foo.txt' in out
+    assert '```' in out
+    assert 'foo' in out
+
+
+def test_to_json():
+    out = to_json(sample_entries())
+    data = json.loads(out)
+    assert data[0]['path'] == 'foo.txt'
+    assert data[0]['content'] == 'foo'


### PR DESCRIPTION
## Summary
- implement simple text, markdown and JSON formatters
- expose formatter helpers
- test each formatter

## Testing
- `pytest -q`