### PR TITLE
Convert tests to unittest

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ pip install -e .
 | **Linting**    | [ruff](https://github.com/astral-sh/ruff)               |
 | **Formatting** | [Black](https://github.com/psf/black)                   |
 | **Docstrings** | NumPy style                                             |
-| **Tests**      | `pytest`                                                |
+| **Tests**      | `unittest`                                              |
 
 ---
 

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -1,29 +1,33 @@
 import json
+import unittest
 from pathlib import Path
 
-from codeatlas.formatter import to_text, to_markdown, to_json
+from codeatlas.formatter import to_markdown, to_json, to_text
 from codeatlas.scanner import FileEntry
 
 
-def sample_entries():
-    return [FileEntry(Path('foo.txt'), size=3, mtime=0.0, content='foo')]
+def sample_entries() -> list[FileEntry]:
+    return [FileEntry(Path("foo.txt"), size=3, mtime=0.0, content="foo")]
 
 
-def test_to_text():
-    out = to_text(sample_entries())
-    assert 'foo.txt' in out
-    assert 'foo' in out
+class TestFormatter(unittest.TestCase):
+    def test_to_text(self) -> None:
+        out = to_text(sample_entries())
+        self.assertIn("foo.txt", out)
+        self.assertIn("foo", out)
+
+    def test_to_markdown(self) -> None:
+        out = to_markdown(sample_entries())
+        self.assertIn("### foo.txt", out)
+        self.assertIn("```", out)
+        self.assertIn("foo", out)
+
+    def test_to_json(self) -> None:
+        out = to_json(sample_entries())
+        data = json.loads(out)
+        self.assertEqual(data[0]["path"], "foo.txt")
+        self.assertEqual(data[0]["content"], "foo")
 
 
-def test_to_markdown():
-    out = to_markdown(sample_entries())
-    assert '### foo.txt' in out
-    assert '```' in out
-    assert 'foo' in out
-
-
-def test_to_json():
-    out = to_json(sample_entries())
-    data = json.loads(out)
-    assert data[0]['path'] == 'foo.txt'
-    assert data[0]['content'] == 'foo'
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    unittest.main()

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1,32 +1,50 @@
 import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
 from codeatlas.tui import AtlasTUI
 
 
-def test_vim_bindings_present():
-    app = AtlasTUI()
-    keys = {b[0] if isinstance(b, tuple) else b.key for b in app.BINDINGS}
-    for key in ("j", "k", "h", "l", "r"):
-        assert key in keys
-    for action in ("move_up", "move_down", "move_left", "move_right", "refresh"):
-        assert hasattr(app, f"action_{action}")
+class TestTUI(unittest.TestCase):
+    def test_vim_bindings_present(self) -> None:
+        app = AtlasTUI()
+        keys = {b[0] if isinstance(b, tuple) else b.key for b in app.BINDINGS}
+        for key in ("j", "k", "h", "l", "r"):
+            self.assertIn(key, keys)
+        for action in (
+            "move_up",
+            "move_down",
+            "move_left",
+            "move_right",
+            "refresh",
+        ):
+            self.assertTrue(hasattr(app, f"action_{action}"))
+
+    def test_state_persistence(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            root = tmp_path / "proj"
+            root.mkdir()
+            config_dir = tmp_path / "conf"
+            state_file = config_dir / "state.json"
+            state_file.parent.mkdir(parents=True)
+            state_file.write_text("{}")
+
+            stored = {str(root.resolve()): ["foo.txt"]}
+            state_file.write_text(json.dumps(stored))
+
+            with patch.dict(os.environ, {"CODEATLAS_CONFIG_DIR": str(config_dir)}):
+                app = AtlasTUI(root)
+                self.assertEqual(app.targets, [root / "foo.txt"])
+
+                app.targets.append(root / "bar.txt")
+                app._save_current_state()
+                new_state = json.loads(state_file.read_text())
+                self.assertEqual(new_state[str(root.resolve())], ["foo.txt", "bar.txt"])
 
 
-def test_state_persistence(tmp_path, monkeypatch):
-    root = tmp_path / "proj"
-    root.mkdir()
-    config_dir = tmp_path / "conf"
-    monkeypatch.setenv("CODEATLAS_CONFIG_DIR", str(config_dir))
-    state_file = config_dir / "state.json"
-    state_file.parent.mkdir(parents=True)
-    state_file.write_text("{}")
-
-    stored = {str(root.resolve()): ["foo.txt"]}
-    state_file.write_text(json.dumps(stored))
-
-    app = AtlasTUI(root)
-    assert app.targets == [root / "foo.txt"]
-
-    app.targets.append(root / "bar.txt")
-    app._save_current_state()
-    new_state = json.loads(state_file.read_text())
-    assert new_state[str(root.resolve())] == ["foo.txt", "bar.txt"]
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    unittest.main()


### PR DESCRIPTION
## Summary
- migrate pytest-style tests to unittest.TestCase
- document using unittest in development guidelines

## Testing
- `pytest -q`
- `python -m unittest discover -s tests -t . -v`
