### PR TITLE
Add batch file for Windows TUI launcher

### DIFF
--- a/codeatlas.bat
+++ b/codeatlas.bat
@@ -1,0 +1,6 @@
+@echo off
+setlocal
+set "SCRIPT_DIR=%~dp0"
+set "PYTHONPATH=%SCRIPT_DIR%src;%PYTHONPATH%"
+python -m codeatlas.tui %*
+endlocal


### PR DESCRIPTION
## Summary
- add `codeatlas.bat` so Windows users can launch the TUI from any directory

## Testing
- `ruff check .` *(fails: module level import issues in existing files)*
- `black . --check` *(fails: would reformat several files)*
- `pytest -q`