### PR TITLE
Activate venv in Windows launcher

### DIFF
--- a/codeatlas.bat
+++ b/codeatlas.bat
@@ -1,6 +1,10 @@
 @echo off
 setlocal
 set "SCRIPT_DIR=%~dp0"
+set "VENV_DIR=%SCRIPT_DIR%.venv"
+if exist "%VENV_DIR%\Scripts\activate.bat" (
+    call "%VENV_DIR%\Scripts\activate.bat"
+)
 set "PYTHONPATH=%SCRIPT_DIR%src;%PYTHONPATH%"
 python -m codeatlas.tui %*
 endlocal


### PR DESCRIPTION
## Summary
- ensure `codeatlas.bat` activates a local `.venv` when present

## Testing
- `pytest -q`