### PR TITLE
Add missing module docstrings

### DIFF
--- a/src/codeatlas/tui.py
+++ b/src/codeatlas/tui.py
@@ -1,3 +1,11 @@
+
+"""Textual user interface for selecting files and directories.
+
+This module provides a small wrapper around :mod:`textual` that lets a user
+pick files or folders from a directory tree.  The selected paths are persisted
+between sessions so that reports can be regenerated easily.
+"""
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -1,3 +1,9 @@
+"""Unit tests for the formatter helpers.
+
+These tests verify that the Markdown, JSON and plain text output functions
+return the expected representations for a set of sample entries.
+"""
+
 import json
 import unittest
 from pathlib import Path

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1,3 +1,9 @@
+"""Unit tests for the Textual user interface.
+
+These tests exercise the key bindings and state persistence logic used by the
+``AtlasTUI`` application.
+"""
+
 import json
 import os
 import tempfile


### PR DESCRIPTION
## Summary
- add a module-level docstring for the TUI module
- document the formatter and TUI tests

## Testing
- `python -m unittest`