### PR TITLE
Handle copy errors in TUI

### DIFF
--- a/src/codeatlas/tui.py
+++ b/src/codeatlas/tui.py
@@ -1,4 +1,3 @@
-
 """Textual user interface for selecting files and directories.
 
 This module provides a small wrapper around :mod:`textual` that lets a user
@@ -186,12 +185,15 @@ class AtlasTUI(App):
         self.exit()
 
     def action_copy(self) -> None:
-        text = self._build_report()
-        if pyperclip is not None:
-            pyperclip.copy(text)
-            self.notify("Copied report to clipboard")
-        else:  # pragma: no cover - clipboard fallback
-            self.notify("pyperclip not available", severity="warning")
+        try:
+            text = self._build_report()
+            if pyperclip is not None:
+                pyperclip.copy(text)
+                self.notify("Copied report to clipboard")
+            else:  # pragma: no cover - clipboard fallback
+                self.notify("pyperclip not available", severity="warning")
+        except Exception as exc:  # pragma: no cover - unexpected errors
+            self.notify(f"Copy failed: {exc}", severity="error")
 
     def _build_report(self) -> str:
         patterns: list[str] = []

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -51,6 +51,18 @@ class TestTUI(unittest.TestCase):
                 new_state = json.loads(state_file.read_text())
                 self.assertEqual(new_state[str(root.resolve())], ["foo.txt", "bar.txt"])
 
+    def test_copy_error_notification(self) -> None:
+        app = AtlasTUI()
+
+        def raise_error() -> str:
+            raise FileNotFoundError("missing.txt")
+
+        app._build_report = raise_error
+        messages: list[str] = []
+        app.notify = lambda msg, **_: messages.append(msg)
+        app.action_copy()
+        self.assertTrue(any("missing.txt" in m for m in messages))
+
 
 if __name__ == "__main__":  # pragma: no cover - manual execution
     unittest.main()


### PR DESCRIPTION
## Summary
- catch exceptions during copy and notify the user
- add unit test for the failure case

## Testing
- `ruff check src tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683a54be68e4832aac9a265a022a4c9c