### PR TITLE
Add debug logging to TUI

### DIFF
--- a/src/codeatlas/tui.py
+++ b/src/codeatlas/tui.py
@@ -11,6 +11,9 @@ from pathlib import Path
 from typing import Iterable, Any
 import os
 import json
+import logging
+
+logger = logging.getLogger(__name__)
 
 from textual.app import App, ComposeResult
 from textual.containers import Horizontal
@@ -32,21 +35,29 @@ CONFIG_ENV = "CODEATLAS_CONFIG_DIR"
 
 def _state_file() -> Path:
     config_dir = Path(os.environ.get(CONFIG_ENV, Path.home() / ".codeatlas"))
-    return config_dir / "state.json"
+    path = config_dir / "state.json"
+    logger.debug("Using state file %s", path)
+    return path
 
 
 def _load_state() -> dict[str, list[str]]:
     path = _state_file()
+    logger.debug("Loading state from %s", path)
     if path.exists():
         try:
-            return json.loads(path.read_text())
-        except Exception:  # pragma: no cover - malformed state
+            data = json.loads(path.read_text())
+            logger.debug("Loaded state: %s", data)
+            return data
+        except Exception as exc:  # pragma: no cover - malformed state
+            logger.warning("Failed to load state: %s", exc)
             return {}
+    logger.debug("State file not found")
     return {}
 
 
 def _save_state(data: dict[str, list[str]]) -> None:
     path = _state_file()
+    logger.debug("Saving state to %s", path)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(data, ensure_ascii=False, indent=2))
 
@@ -72,6 +83,7 @@ class PathItem(ListItem):
     ) -> None:  # pragma: no cover - UI interaction
         """Remove the item on double click."""
         if event.chain == 2:
+            logger.debug("PathItem double clicked: %s", self.path)
             app = self.app
             if hasattr(app, "remove_path_item"):
                 app.remove_path_item(self)
@@ -100,11 +112,14 @@ class AtlasTUI(App):
         self._state = _load_state()
         stored = self._state.get(str(self.root), [])
         self.targets: list[Path] = [self.root / Path(p) for p in stored]
+        logger.debug("AtlasTUI initialized with root %s", self.root)
+        logger.debug("Initial targets: %s", self.targets)
 
     def _save_current_state(self) -> None:
         self._state[str(self.root)] = [
             p.relative_to(self.root).as_posix() for p in self.targets
         ]
+        logger.debug("Saving current state: %s", self._state)
         _save_state(self._state)
 
     def _cursor_action(self, name: str) -> None:
@@ -132,6 +147,11 @@ class AtlasTUI(App):
 
     def on_click(self, event: events.Click) -> None:
         """Handle click events, specifically double-clicks on directory tree."""
+        logger.debug(
+            "on_click: chain=%s sender=%s",
+            event.chain,
+            type(event.sender).__name__ if event.sender else None,
+        )
         # Check if it's a double-click on the directory tree
         if (
             event.chain == 2
@@ -139,6 +159,7 @@ class AtlasTUI(App):
             and event.sender is self.dir_tree
         ):
             # Defer action until after the tree updates its selection
+            logger.debug("Double click detected on directory tree")
             self.call_later(self.action_add)
             event.stop()
 
@@ -152,20 +173,27 @@ class AtlasTUI(App):
         yield Footer()
 
     def on_mount(self) -> None:
+        logger.debug("Mounting with %d targets", len(self.targets))
         for path in self.targets:
             self.list_view.append(PathItem(path))
 
     def action_add(self) -> None:
         node = self.dir_tree.cursor_node
+        logger.debug("action_add called; node=%s", node)
         if node and node.data:
             path = node.data.path
+            logger.debug("Selected path: %s", path)
             if path not in self.targets:
+                logger.debug("Adding path to targets")
                 self.targets.append(path)
                 self.list_view.append(PathItem(path))
                 self._save_current_state()
+            else:
+                logger.debug("Path already in targets")
 
     def action_remove(self) -> None:
         if self.list_view.index is not None:
+            logger.debug("Removing item at index %d", self.list_view.index)
             self._remove_index(self.list_view.index)
 
     def remove_path_item(self, item: PathItem) -> None:
@@ -173,17 +201,21 @@ class AtlasTUI(App):
         items = list(self.list_view.query(PathItem))
         if item in items:
             idx = items.index(item)
+            logger.debug("Removing PathItem at index %d", idx)
             self._remove_index(idx)
 
     def _remove_index(self, idx: int) -> None:
+        logger.debug("_remove_index %d", idx)
         self.list_view.remove_items([idx])
         del self.targets[idx]
         self._save_current_state()
 
     def action_refresh(self) -> None:
+        logger.debug("Refreshing directory tree")
         self.dir_tree.reload()
 
     async def action_quit(self) -> None:
+        logger.debug("Quitting application")
         self._save_current_state()
         self.exit()
 


### PR DESCRIPTION
## Summary
- insert extensive debug logging into the TUI implementation

## Testing
- `black src/codeatlas/tui.py`
- `ruff check src/codeatlas/tui.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683adcbec7b0832a82396b8e609d355c