### PR TITLE
Fix long filename display

### DIFF
--- a/src/codeatlas/tui.py
+++ b/src/codeatlas/tui.py
@@ -71,12 +71,34 @@ except Exception:  # pragma: no cover - fallback when pyperclip unavailable
     pyperclip = None
 
 
+def _shorten_left(text: str, width: int) -> str:
+    """Return ``text`` truncated on the left with an ellipsis if needed."""
+    if width <= 0:
+        return ""
+    if len(text) <= width:
+        return text
+    if width == 1:
+        return text[-1]
+    return "\u2026" + text[-(width - 1) :]
+
+
 class PathItem(ListItem):
     """List item storing a filesystem path."""
 
     def __init__(self, path: Path) -> None:
-        super().__init__(Label(path.as_posix()))
         self.path = path
+        self.label = Label(path.as_posix())
+        super().__init__(self.label)
+
+    def _update_label(self) -> None:
+        width = self.size.width or self.app.size.width // 2
+        self.label.update(_shorten_left(self.path.as_posix(), width))
+
+    def on_mount(self) -> None:  # pragma: no cover - UI interaction
+        self._update_label()
+
+    def on_resize(self, event: events.Resize) -> None:  # pragma: no cover - UI interaction
+        self._update_label()
 
     def on_click(
         self, event: events.Click

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -11,7 +11,7 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
-from codeatlas.tui import AtlasTUI
+from codeatlas.tui import AtlasTUI, _shorten_left
 from textual import events
 
 
@@ -83,6 +83,12 @@ class TestTUI(unittest.TestCase):
                 pass
             else:
                 raise
+
+    def test_shorten_left(self) -> None:
+        self.assertEqual(_shorten_left("abcdef", 10), "abcdef")
+        self.assertEqual(_shorten_left("abcdef", 3), "\u2026ef")
+        self.assertEqual(_shorten_left("abcdef", 1), "f")
+
     def test_copy_error_notification(self) -> None:
         app = AtlasTUI()
 


### PR DESCRIPTION
## Summary
- truncate file paths from the start so endings remain visible in the TUI
- unit test the shortening helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683adef3a5b8832a9ca4f767c5632aea